### PR TITLE
Disable default options from selection

### DIFF
--- a/paypal_credit_card_form.html
+++ b/paypal_credit_card_form.html
@@ -7,7 +7,7 @@
 		<div class='form-group'>
 		  <label for='card_type'>Card Type</label>
 		  <select name='card_type' id='card-type'>
-		  	<option selected="selected">Card Type</option>
+		  	<option selected="selected" disabled>Card Type</option>
 		    <option value='visa'> Visa </option>
 		    <option value='mastercard'> Mastercard </option>
 		    <option value='americanexpress'> American Express </option>
@@ -21,7 +21,7 @@
 		<div class='form-group'>
 		  <label for='expire_month'>Expiration Month</label>
 		  <select name='expire_month' id='expire-month'>
-		  	<option selected="selected">Expiration Month</option>
+		  	<option selected="selected" disabled>Expiration Month</option>
 		    <option value='01'> 1 - Jan </option>
 		    <option value='02'> 2 - Feb </option>
 		    <option value='03'> 3 - Mar </option>
@@ -39,7 +39,7 @@
 		<div class='form-group'>
 		  <label for='expire_year'>Expiration Year</label>
 		  <select name='expire_year' id='expire-year'>
-		  	<option selected="selected">Expiration Year</option>
+		  	<option selected="selected" disabled>Expiration Year</option>
 		    <option value='2013'>2013</option>
 		    <option value='2014'>2014</option>
 		    <option value='2015'>2015</option>


### PR DESCRIPTION
For instance: The user now cannot select "Expiration Year" as their expiration year once they've selected a date.
